### PR TITLE
Made some changes to constructor signature to support use from INI-style logging config

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,13 +9,16 @@ It allows colors to be placed in the format string, which is mostly useful when 
 Usage
 =====
 
-``ColoredFormatter`` requires at minumum a format string, and takes two options - ``reset`` (implictly add a reset  code at the end of message strings, defaults to true) and ``color_levels`` (a mapping of record level names to color names, defaults to ``colorlog.DEFAULT_COLOR_LEVELS``).
+From Python
+-----------
+
+``ColoredFormatter`` requires at minumum a format string, and takes several options - ``datefmt`` (an optional date format string passed to base class), ``reset`` (implictly add a reset  code at the end of message strings, defaults to true), and ``log_colors`` (a mapping of record level names to color names, defaults to ``colorlog.default_log_colors``).
 
 ::
 
 	from colorlog import ColoredFormatter
 
-	formatstring = "%(bg_level)s%(levelname)-8s%(reset)s %(blue)%(message)s"
+	formatstring = "%(log_color)s%(levelname)-8s%(reset)s %(blue)s%(message)s"
 
 	levels = {
 		'DEBUG':    'cyan',
@@ -28,6 +31,19 @@ Usage
 	formatter = ColoredFormatter(formatstring, reset=True, color_levels=levels)
 
 The formatter can then be used in a normal ``logging`` setup.
+
+From Configuration File
+-----------------------
+
+The ``ColoredFormatter`` may also be instantiated. from a standard logging (INI-style) configuration file.  Notably, it will only be passed the format and datefmt parameters by the python logging format initializer (all other params will be default).
+
+::
+	[formatter_color]
+	format=%(asctime)s,%(msecs)03d %(levelname)-8s %(log_color)s%(threadName)s %(message)s
+	datefmt = %m-%d %H:%M:%S
+	class = colorlog.ColoredFormatter
+
+The formatter will then be used by any handlers that are configured to use the ``color`` logger (for example above).
 
 Codes
 =====

--- a/colorlog/colorlog.py
+++ b/colorlog/colorlog.py
@@ -16,14 +16,15 @@ default_log_colors =  {
 class ColoredFormatter (logging.Formatter):
 	"""	A formatter that allows colors to be placed in the format string, intended to help in creating prettier, more readable logging output. """
 
-	def __init__ (self, format, log_colors=default_log_colors, reset=False):
+	def __init__ (self, format, datefmt=None, log_colors=default_log_colors, reset=True):
 		"""
 		:Parameters:
 		- format (str): The format string to use
+		- datefmt (str): Allow for special date formatting (if ommited, standard ISO8601 formatting applied by base class).
 		- log_colors (dict): A mapping of log level names to color names
 		- reset (bool): Implictly appends a reset code to all records unless set to False
 		"""
-		super(ColoredFormatter, self).__init__(format)
+		super(ColoredFormatter, self).__init__(format, datefmt)
 		self.log_colors = log_colors
 		self.reset = reset
 
@@ -40,8 +41,8 @@ class ColoredFormatter (logging.Formatter):
 		# Format the message
 		message = super(ColoredFormatter, self).format(record)
 
-		# Add a reset code to the end of the message
-		if not self.reset:
+		# Add a reset code to the end of the message (if it wasn't explicitly added in format str)
+		if self.reset and not message.endswith(escape_codes['reset']):
 			message += escape_codes['reset']
 
 		return message


### PR DESCRIPTION
I would like to use your module on several projects, but want to be able have it work just using standard python logging config.  (All of our projects at work are configured this way.)  The current constructor signature precludes this, since the python logging framework will instantiate custom Formatter classes with two params: (fmt, datefmt). 

So, I made some changes to accommodate this -- and also fixed a few things that appeared to be bugs/oversights:
- Added a datefmt param as second parameter, defaults to None, simply gets passed up to parent class constructor.
- Changed the reset param to default to True (to match what the README said and also that logic in the method) -- also added a default check for existing reset escape sequence termination.
- Updated the README to include mention of using the logging INI config that is now supported.  Also fixed the example usage, since that format string did not work for me. 

Hope that this makes sense and we can use a 1.4 (or whatever) version.  Thanks!
