### PR TITLE
Changed from using super to support python 2.6 old-style logging classes.

### DIFF
--- a/colorlog/colorlog.py
+++ b/colorlog/colorlog.py
@@ -24,7 +24,7 @@ class ColoredFormatter (logging.Formatter):
 		- log_colors (dict): A mapping of log level names to color names
 		- reset (bool): Implictly appends a reset code to all records unless set to False
 		"""
-		super(ColoredFormatter, self).__init__(format, datefmt)
+		logging.Formatter.__init__(self, format, datefmt)
 		self.log_colors = log_colors
 		self.reset = reset
 
@@ -39,7 +39,7 @@ class ColoredFormatter (logging.Formatter):
 			record.log_color = escape_codes[color]
 
 		# Format the message
-		message = super(ColoredFormatter, self).format(record)
+		message = logging.Formatter.format(self, record)
 
 		# Add a reset code to the end of the message (if it wasn't explicitly added in format str)
 		if self.reset and not message.endswith(escape_codes['reset']):


### PR DESCRIPTION
Changed from using super() since apparently in python2.6 logging.Formatter is still an old-style class.

... I would understand perfectly if you didn't want to accept this, but in case you have a desire to support python 2.6 (I have to still, unfortunately).  I have not tested this directly; I modified the installed version on my python 2.6 production box; however, I note that the installed version is a little different (I'm assuming due to 2to3 running on the files or something).
