### PR TITLE
Don't modify original record object

### DIFF
--- a/colorlog/colorlog.py
+++ b/colorlog/colorlog.py
@@ -3,6 +3,7 @@
 from __future__ import absolute_import
 
 import logging
+import copy
 import sys
 
 from colorlog.escape_codes import escape_codes
@@ -51,7 +52,8 @@ class ColoredFormatter(logging.Formatter):
         self.reset = reset
 
     def format(self, record):
-        # Add the color codes to the record
+        # Add the color codes to the copy of record
+        record = copy.copy(record)
         record.__dict__.update(escape_codes)
 
         # If we recognise the level name,


### PR DESCRIPTION
Modifying the original object leads to the fact that in complex configurations where the logs are sent to the server record also includes extra fields.