### PR TITLE
Add datefmt to passed arguments within decorated basicConfig

### DIFF
--- a/colorlog/logging.py
+++ b/colorlog/logging.py
@@ -17,7 +17,8 @@ def basicConfig(**kwargs):
     try:
         stream = logging.root.handlers[0]
         stream.setFormatter(
-            ColoredFormatter(kwargs.get('format', BASIC_FORMAT)))
+            ColoredFormatter(kwargs.get('format', BASIC_FORMAT),
+                             datefmt=kwargs.get('datefmt')))
     finally:
         logging._releaseLock()
 


### PR DESCRIPTION
At the moment the datefmt argument is not respected when using basicConfig from colorlog. With this commit it will be passed along with the default format string to the ColoredFormatter.