### PR TITLE
Disable coloring if not attached to a terminal

### DIFF
--- a/colorlog/__init__.py
+++ b/colorlog/__init__.py
@@ -3,12 +3,12 @@
 from __future__ import absolute_import
 
 from colorlog.colorlog import (
-    ColoredFormatter, escape_codes, default_log_colors)
+    ColoredFormatter, FilteredStreamHandler, escape_codes, default_log_colors)
 
 from colorlog.logging import (
     basicConfig, root, getLogger, log,
     debug, info, warning, error, exception, critical)
 
-__all__ = ('ColoredFormatter', 'default_log_colors', 'escape_codes',
-           'basicConfig', 'root', 'getLogger', 'debug', 'info', 'warning',
-           'error', 'exception', 'critical', 'log', 'exception')
+__all__ = ('ColoredFormatter', 'FilteredStreamHandler', 'default_log_colors',
+           'escape_codes', 'basicConfig', 'root', 'getLogger', 'debug', 'info',
+           'warning', 'error', 'exception', 'critical', 'log', 'exception')


### PR DESCRIPTION
Otherwise redirecting the log output to a file will mess up the output.
