### PR TITLE
Fix extras_require for win32

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     ],
 
     extras_require={
-        'windows': [
+        ':sys_platform=="win32"': [
             'colorama'
         ]
     },


### PR DESCRIPTION
Hi there,

I noticed that **colorlog** does not properly install **colorama** on windows. After changing ``extras_require`` according to the [official wheel docs](https://wheel.readthedocs.org/en/latest/#defining-conditional-dependencies) on conditional requirements it seems to work just fine.

Please let me know your thoughts! :bow: 