### PR TITLE
Add support for per-loglevel formatting

### DIFF
--- a/colorlog/__init__.py
+++ b/colorlog/__init__.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 
 from colorlog.colorlog import (
     ColoredFormatter, escape_codes, default_log_colors,
-    ColoredLevelFormatter)
+    LevelFormatter)
 
 from colorlog.logging import (
     basicConfig, root, getLogger, log,
@@ -13,4 +13,4 @@ from colorlog.logging import (
 __all__ = ('ColoredFormatter', 'default_log_colors', 'escape_codes',
            'basicConfig', 'root', 'getLogger', 'debug', 'info', 'warning',
            'error', 'exception', 'critical', 'log', 'exception',
-           'StreamHandler', 'ColoredLevelFormatter')
+           'StreamHandler', 'LevelFormatter')

--- a/colorlog/__init__.py
+++ b/colorlog/__init__.py
@@ -3,7 +3,8 @@
 from __future__ import absolute_import
 
 from colorlog.colorlog import (
-    ColoredFormatter, escape_codes, default_log_colors)
+    ColoredFormatter, escape_codes, default_log_colors,
+    ColoredLevelFormatter)
 
 from colorlog.logging import (
     basicConfig, root, getLogger, log,
@@ -12,4 +13,4 @@ from colorlog.logging import (
 __all__ = ('ColoredFormatter', 'default_log_colors', 'escape_codes',
            'basicConfig', 'root', 'getLogger', 'debug', 'info', 'warning',
            'error', 'exception', 'critical', 'log', 'exception',
-           'StreamHandler')
+           'StreamHandler', 'ColoredLevelFormatter')

--- a/colorlog/colorlog.py
+++ b/colorlog/colorlog.py
@@ -81,9 +81,6 @@ class ColoredFormatter(logging.Formatter):
 
         :Parameters:
         - fmt (str): The format string to use
-        - fmt (dict):
-            A mapping of log levels (represented as strings, e.g. 'WARNING') to
-            different formatters. (*New in version <TBD>)  # TODO: version?
         - datefmt (str): A format string for the date
         - log_colors (dict):
             A mapping of log level names to color names
@@ -143,9 +140,7 @@ class ColoredFormatter(logging.Formatter):
 
 class ColoredLevelFormatter(ColoredFormatter):
     """
-    A formatter that allows colors to be placed in the format string.
-
-    Intended to help in creating more readable logging output.
+    An Extension of ColoredFormatter that uses per-loglevel format strings.
     """
 
     def __init__(self, fmt=None, datefmt=None, style='%',

--- a/colorlog/colorlog.py
+++ b/colorlog/colorlog.py
@@ -167,16 +167,7 @@ class ColoredFormatter(logging.Formatter):
 
         # Customize formatter per log level
         if self.level_fmts is not None:
-            if record.levelno == logging.DEBUG:
-                self._fmt = self.level_fmts['DEBUG']
-            elif record.levelno == logging.INFO:
-                self._fmt = self.level_fmts['INFO']
-            elif record.levelno == logging.WARNING:
-                self._fmt = self.level_fmts['WARNING']
-            elif record.levelno == logging.ERROR:
-                self._fmt = self.level_fmts['ERROR']
-            elif record.levelno == logging.CRITICAL:
-                self._fmt = self.level_fmts['CRITICAL']
+            self._fmt = self.level_fmts[record.levelname]
 
             if sys.version_info > (3, 2):
                 # Update self._style because we've changed self._fmt

--- a/colorlog/colorlog.py
+++ b/colorlog/colorlog.py
@@ -115,6 +115,13 @@ class ColoredFormatter(logging.Formatter):
             The format style to use. (*No meaning prior to Python 3.2.*)
         - secondary_log_colors (dict):
             Map secondary ``log_color`` attributes. (*New in version 2.6.*)
+        - level_fmts (dict):
+            Map log levels (represented as strings, e.g. 'WARNING') to
+            different formatters. (*New in version <TBD>)  # TODO: version?
+            - If ``None``, use the formatter given in the ``fmt`` argument
+              instead (default behavior).
+            - If 'default', use a default mapping that differentiates
+              the log levels.
         """
         if fmt is None:
             if sys.version_info > (3, 2):

--- a/colorlog/colorlog.py
+++ b/colorlog/colorlog.py
@@ -9,7 +9,7 @@ import sys
 from colorlog.escape_codes import escape_codes, parse_colors
 
 __all__ = ('escape_codes', 'default_log_colors', 'ColoredFormatter',
-           'ColoredLevelFormatter')
+           'LevelFormatter')
 
 # The default colors to use for the debug levels
 default_log_colors = {
@@ -138,7 +138,7 @@ class ColoredFormatter(logging.Formatter):
         return message
 
 
-class ColoredLevelFormatter(ColoredFormatter):
+class LevelFormatter(ColoredFormatter):
     """
     An Extension of ColoredFormatter that uses per-loglevel format strings.
     """
@@ -160,7 +160,7 @@ class ColoredLevelFormatter(ColoredFormatter):
 
         Example:
 
-        formatter = colorlog.ColoredLevelFormatter(fmt={
+        formatter = colorlog.LevelFormatter(fmt={
             'DEBUG':'%(log_color)s%(msg)s (%(module)s:%(lineno)d)',
             'INFO': '%(log_color)s%(msg)s',
             'WARNING': '%(log_color)sWARN: %(msg)s (%(module)s:%(lineno)d)',
@@ -169,7 +169,7 @@ class ColoredLevelFormatter(ColoredFormatter):
         })
         """
         if sys.version_info > (2, 7):
-            super(ColoredLevelFormatter, self).__init__(
+            super(LevelFormatter, self).__init__(
                 fmt=fmt, datefmt=datefmt, style=style, log_colors=log_colors,
                 reset=reset, secondary_log_colors=secondary_log_colors)
         else:
@@ -193,7 +193,7 @@ class ColoredLevelFormatter(ColoredFormatter):
                 self._style = logging._STYLES[self.style][0](self._fmt)
 
         if sys.version_info > (2, 7):
-            message = super(ColoredLevelFormatter, self).format(record)
+            message = super(LevelFormatter, self).format(record)
         else:
             message = ColoredFormatter.format(self, record)
 

--- a/colorlog/colorlog.py
+++ b/colorlog/colorlog.py
@@ -27,31 +27,6 @@ default_formats = {
     '$': '${log_color}${levelname}:${name}:${message}'
 }
 
-# Level-based default formatters
-default_level_formats = {
-    '%': {
-        'DEBUG': '%(log_color)s%(msg)s (%(module)s:%(lineno)d)',
-        'INFO': '%(log_color)s%(msg)s',
-        'WARNING': '%(log_color)sWARNING: %(msg)s (%(module)s:%(lineno)d)',
-        'ERROR': '%(log_color)sERROR: %(msg)s (%(module)s:%(lineno)d)',
-        'CRITICAL': '%(log_color)sCRITICAL: %(msg)s (%(module)s:%(lineno)d)',
-    },
-    '{': {
-        'DEBUG': '{log_color}{msg} ({module}:{lineno})',
-        'INFO': '{log_color}{msg}',
-        'WARNING': '{log_color}WARNING: {msg} ({module}:{lineno})',
-        'ERROR': '{log_color}ERROR: {msg} ({module}:{lineno})',
-        'CRITICAL': '{log_color}CRITICAL: {msg} ({module}:{lineno})',
-    },
-    '$': {
-        'DEBUG': '${log_color}${msg} (${module}:${lineno})',
-        'INFO': '${log_color}${msg}',
-        'WARNING': '${log_color}WARNING: ${msg} (${module}:${lineno})',
-        'ERROR': '${log_color}ERROR: ${msg} (${module}:${lineno})',
-        'CRITICAL': '${log_color}CRITICAL: ${msg} (${module}:${lineno})',
-    },
-}
-
 
 class ColoredRecord(object):
     """


### PR DESCRIPTION
This makes it possible to specify a formatter dictionary that enables colorlog to format messages differently based on their log level.

Use case:
- If you want to log informational output using `logger.info()`, you are rarely interested in the module and line number where the message comes from.
- On the other hand, it can be useful to prefix warnings, errors and criticals with 'WARNING: ' etc. and add line number and module at the end, for example.

This is why I added the `level_fmts` argument to ColoredFormatter.

I tested the new code with Python 2.7 and Python 3.5.

Possible issues:
- `default_level_formats` has nothing to do with colorlog's normal `default_formats`. Could this be confusing?
- We could reuse the `fmt` argument instead of introducing the new `level_fmts`. We would need to check if `fmt` is a dict or a string in `ColoredFormatter.__init__()` and could use it differently depending on the type. I don't know if that would be better. What is your opinion?