### PR TITLE
Remove qutebrowser from projects using colorlog

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,6 @@ Projects using colorlog
 - [Counterparty]
 - [Errbot]
 - [Pythran]
-- [Qutebrowser]
 - [zenlog]
 
 Licence
@@ -221,6 +220,5 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 [Gentoo]: https://packages.gentoo.org/packages/dev-python/colorlog
 [OpenSuse]: http://rpm.pbone.net/index.php3?stat=3&search=python-colorlog&srodzaj=3
 [Pythran]: http://pythonhosted.org/pythran/DEVGUIDE.html
-[Qutebrowser]: http://www.qutebrowser.org/
 [Ubuntu]: https://launchpad.net/python-colorlog
 [zenlog]: https://github.com/ManufacturaInd/python-zenlog


### PR DESCRIPTION
No hard feelings - I just [found it simpler](https://github.com/The-Compiler/qutebrowser/commit/c64e5c9bd595ef310825d07bf29e1d3eb7674714) to implement the bits I needed by hand instead of using `colorlog`, and since it's not commonly packaged with distributions it was an optional dependency either way.

Thanks for your work though!