### PR TITLE
Fix Python 2.6 incompatibility in ColoredRecord.__dict.__missing__

### DIFF
--- a/colorlog/colorlog.py
+++ b/colorlog/colorlog.py
@@ -42,7 +42,7 @@ class ColoredRecord(object):
             try:
                 return parse_colors(name)
             except Exception:
-                raise KeyError("{} is not a valid record attribute "
+                raise KeyError("{0} is not a valid record attribute "
                                "or color sequence".format(name))
 
     def __init__(self, record):


### PR DESCRIPTION
Ran into a "ValueError: zero length field name in format" in colorlog.py:46 while hitting this code branch on Python 2.6, since that version still requires indices in the format placeholders.