### PR TITLE
Remove ColoredRecord class

### DIFF
--- a/colorlog/colorlog.py
+++ b/colorlog/colorlog.py
@@ -27,27 +27,6 @@ default_formats = {
 }
 
 
-class ColoredRecord(object):
-    """
-    Wraps a LogRecord, adding named escape codes to the internal dict.
-
-    The internal dict is used when formatting the message (by the PercentStyle,
-    StrFormatStyle, and StringTemplateStyle classes).
-    """
-
-    def __init__(self, record):
-        """Add attributes from the escape_codes dict and the record."""
-        self.__dict__.update(escape_codes)
-        self.__dict__.update(record.__dict__)
-
-        # Keep a reference to the original record so ``__getattr__`` can
-        # access functions that are not in ``__dict__``
-        self.__record = record
-
-    def __getattr__(self, name):
-        return getattr(self.__record, name)
-
-
 class ColoredFormatter(logging.Formatter):
     """
     A formatter that allows colors to be placed in the format string.
@@ -105,7 +84,7 @@ class ColoredFormatter(logging.Formatter):
 
     def format(self, record):
         """Format a message from a record object."""
-        record = ColoredRecord(record)
+        record.__dict__.update(escape_codes)
         record.log_color = self.color(self.log_colors, record.levelname)
 
         # Set secondary log colors


### PR DESCRIPTION
This intends to solve a rare problem I had encountered.
I use both colorlog and [multiprocessing-logging](https://github.com/jruere/multiprocessing-logging). I noticed that in the subprocesses, if I call _logger.exception_, I do get the message but not the traceback. I tracked down the issue to [this line](https://github.com/jruere/multiprocessing-logging/blob/master/multiprocessing_logging.py#L75), where multiprocessing-logging calls format(record), expecting the formatter to [set record.exc_text](https://github.com/python/cpython/blob/master/Lib/logging/__init__.py#L572). Since the ColoredFormatter wraps the record before calling the base class, the original record doesn't get it's exc_text set, and I lose my traceback.
I think that this issue is much easier to fix in colorlog. I removed the ColoredRecord and instead just set the escape code properties to the original record.