### PR TITLE
Include doc in source distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include README.md
 include LICENSE
 include colorlog/tests/test_config.ini
+graft doc


### PR DESCRIPTION
Hi!
We at Gentoo use PyPI tarballs to build docs, could you please add them to future releases?