### PR TITLE
Fix for LevelFormatter in Python >= 3.8

### DIFF
--- a/colorlog/colorlog.py
+++ b/colorlog/colorlog.py
@@ -87,8 +87,10 @@ class ColoredFormatter(logging.Formatter):
             else:
                 fmt = default_formats['%']
 
-        if sys.version_info > (3, 8) and isinstance(self, LevelFormatter) and isinstance(fmt, dict):
-            super(ColoredFormatter, self).__init__(fmt, datefmt, style, validate=False)
+        if sys.version_info > (3, 8) and isinstance(self, LevelFormatter) \
+                and isinstance(fmt, dict):
+            super(ColoredFormatter, self).__init__(
+                fmt, datefmt, style, validate=False)
         elif sys.version_info > (3, 2):
             super(ColoredFormatter, self).__init__(fmt, datefmt, style)
         elif sys.version_info > (2, 7):

--- a/colorlog/colorlog.py
+++ b/colorlog/colorlog.py
@@ -87,6 +87,8 @@ class ColoredFormatter(logging.Formatter):
             else:
                 fmt = default_formats['%']
 
+        if sys.version_info > (3, 8) and isinstance(self, LevelFormatter):
+            super(ColoredFormatter, self).__init__(fmt, datefmt, style, validate=False)
         if sys.version_info > (3, 2):
             super(ColoredFormatter, self).__init__(fmt, datefmt, style)
         elif sys.version_info > (2, 7):

--- a/colorlog/colorlog.py
+++ b/colorlog/colorlog.py
@@ -87,9 +87,9 @@ class ColoredFormatter(logging.Formatter):
             else:
                 fmt = default_formats['%']
 
-        if sys.version_info > (3, 8) and isinstance(self, LevelFormatter):
+        if sys.version_info > (3, 8) and isinstance(self, LevelFormatter) and isinstance(fmt, dict):
             super(ColoredFormatter, self).__init__(fmt, datefmt, style, validate=False)
-        if sys.version_info > (3, 2):
+        elif sys.version_info > (3, 2):
             super(ColoredFormatter, self).__init__(fmt, datefmt, style)
         elif sys.version_info > (2, 7):
             super(ColoredFormatter, self).__init__(fmt, datefmt)


### PR DESCRIPTION
Details: https://github.com/borntyping/python-colorlog/issues/77
TL;DR: Python 3.8 lib's logging added a validation check, which does not accept dict as a valid Formatter fmt