### PR TITLE
Add parameters to basic config

### DIFF
--- a/colorlog/logging.py
+++ b/colorlog/logging.py
@@ -10,7 +10,7 @@ from colorlog.colorlog import ColoredFormatter
 BASIC_FORMAT = "%(log_color)s%(levelname)s%(reset)s:%(name)s:%(message)s"
 
 
-def basicConfig(**kwargs):
+def basicConfig(style='%', log_colors=None, reset=True, secondary_log_colors=None, **kwargs):
     """Call ``logging.basicConfig`` and override the formatter it creates."""
     logging.basicConfig(**kwargs)
     logging._acquireLock()
@@ -19,7 +19,12 @@ def basicConfig(**kwargs):
         stream.setFormatter(
             ColoredFormatter(
                 fmt=kwargs.get('format', BASIC_FORMAT),
-                datefmt=kwargs.get('datefmt', None)))
+                datefmt=kwargs.get('datefmt', None),
+                style=style,
+                log_colors=log_colors,
+                reset=reset,
+                secondary_log_colors=secondary_log_colors
+            ))
     finally:
         logging._releaseLock()
 

--- a/colorlog/logging.py
+++ b/colorlog/logging.py
@@ -10,7 +10,8 @@ from colorlog.colorlog import ColoredFormatter
 BASIC_FORMAT = "%(log_color)s%(levelname)s%(reset)s:%(name)s:%(message)s"
 
 
-def basicConfig(style='%', log_colors=None, reset=True, secondary_log_colors=None, **kwargs):
+def basicConfig(style='%', log_colors=None, reset=True, 
+                secondary_log_colors=None, **kwargs):
     """Call ``logging.basicConfig`` and override the formatter it creates."""
     logging.basicConfig(**kwargs)
     logging._acquireLock()

--- a/colorlog/logging.py
+++ b/colorlog/logging.py
@@ -10,7 +10,7 @@ from colorlog.colorlog import ColoredFormatter
 BASIC_FORMAT = "%(log_color)s%(levelname)s%(reset)s:%(name)s:%(message)s"
 
 
-def basicConfig(style='%', log_colors=None, reset=True, 
+def basicConfig(style='%', log_colors=None, reset=True,
                 secondary_log_colors=None, **kwargs):
     """Call ``logging.basicConfig`` and override the formatter it creates."""
     logging.basicConfig(**kwargs)

--- a/colorlog/logging.py
+++ b/colorlog/logging.py
@@ -10,7 +10,7 @@ from colorlog.colorlog import ColoredFormatter
 BASIC_FORMAT = "%(log_color)s%(levelname)s%(reset)s:%(name)s:%(message)s"
 
 
-def basicConfig(**kwargs):
+def basicConfig(style='%', log_colors=None, reset=True, secondary_log_colors=None, **kwargs):
     """Call ``logging.basicConfig`` and override the formatter it creates."""
     logging.basicConfig(**kwargs)
     logging._acquireLock()
@@ -20,10 +20,10 @@ def basicConfig(**kwargs):
             ColoredFormatter(
                 fmt=kwargs.get('format', BASIC_FORMAT),
                 datefmt=kwargs.get('datefmt', None),
-                style=kwargs.get('style', '%'),
-                log_colors=kwargs.pop('log_colors', None),
-                reset=kwargs.pop('reset', True),
-                secondary_log_colors=kwargs.pop('secondary_log_colors', None)
+                style=style,
+                log_colors=log_colors,
+                reset=reset,
+                secondary_log_colors=secondary_log_colors
             ))
     finally:
         logging._releaseLock()

--- a/colorlog/logging.py
+++ b/colorlog/logging.py
@@ -10,7 +10,7 @@ from colorlog.colorlog import ColoredFormatter
 BASIC_FORMAT = "%(log_color)s%(levelname)s%(reset)s:%(name)s:%(message)s"
 
 
-def basicConfig(style='%', log_colors=None, reset=True, secondary_log_colors=None, **kwargs):
+def basicConfig(**kwargs):
     """Call ``logging.basicConfig`` and override the formatter it creates."""
     logging.basicConfig(**kwargs)
     logging._acquireLock()
@@ -20,10 +20,10 @@ def basicConfig(style='%', log_colors=None, reset=True, secondary_log_colors=Non
             ColoredFormatter(
                 fmt=kwargs.get('format', BASIC_FORMAT),
                 datefmt=kwargs.get('datefmt', None),
-                style=style,
-                log_colors=log_colors,
-                reset=reset,
-                secondary_log_colors=secondary_log_colors
+                style=kwargs.get('style', '%'),
+                log_colors=kwargs.pop('log_colors', None),
+                reset=kwargs.pop('reset', True),
+                secondary_log_colors=kwargs.pop('secondary_log_colors', None)
             ))
     finally:
         logging._releaseLock()


### PR DESCRIPTION
Add parameters for `ColoredFormatter` to the `basicConfig` function call to allow alternative formatting when calling `basicConfig`. Backwards compatibility is kept and defaults are used if nothing new is passed to the call.

Changes applied according to the discussion in https://github.com/borntyping/python-colorlog/issues/79#issue-541760907