### PR TITLE
TTYColoredFormatter: check for `isatty` existence

### DIFF
--- a/colorlog/colorlog.py
+++ b/colorlog/colorlog.py
@@ -204,7 +204,7 @@ class TTYColoredFormatter(ColoredFormatter):
         self.stream = kwargs.pop('stream')
 
         # Both `reset` and `isatty` must be true to insert reset codes.
-        kwargs['reset'] = kwargs.get('reset', True) and self.stream.isatty()
+        kwargs['reset'] = kwargs.get('reset', True) and hasattr(self.stream, 'isatty') and self.stream.isatty()
 
         ColoredFormatter.__init__(self, *args, **kwargs)
 

--- a/colorlog/colorlog.py
+++ b/colorlog/colorlog.py
@@ -210,6 +210,6 @@ class TTYColoredFormatter(ColoredFormatter):
 
     def color(self, log_colors, level_name):
         """Only returns colors if STDOUT is a TTY."""
-        if not self.stream.isatty():
+        if not hasattr(self.stream, 'isatty') or not self.stream.isatty():
             log_colors = {}
         return ColoredFormatter.color(self, log_colors, level_name)


### PR DESCRIPTION
### Changes
Ensure `isatty` method exists on the provided stream before to actually call it.

### Why?
That would prevent an `AttributeError` to be raised if such method does not exist.
A use case would be when writing logging records to Autodesk Maya Output that does not have any `isatty` method.

### Note
Backward compatibility is preserved.