### PR TITLE
Fix inclusion of tests and docs

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 global-exclude *.py[co]
 recursive-include colorlog/tests/ *.py *.ini
-recursive-include doc/ *.py
+recursive-include doc/ *.py *.png
 include LICENSE
 include README.md

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 global-exclude *.py[co]
-include colorlog/tests/
-include doc/
+recursive-include colorlog/tests/ *.py *.ini
+recursive-include doc/ *.py
 include LICENSE
 include README.md


### PR DESCRIPTION
As mentioned in #90. Be sure to use clean build dirs when testing what gets included in the PyPI distributables, e.g. `rm -rf build dist` unless this is done from a clean checkout.

```
$ rm -rf build dist

$ python setup.py sdist bdist_wheel
[...]

$ unzip -l dist/colorlog-4.5.0-py2.py3-none-any.whl 
Archive:  dist/colorlog-4.5.0-py2.py3-none-any.whl
  Length      Date    Time    Name
---------  ---------- -----   ----
      635  2020-11-06 12:22   colorlog/__init__.py
     7982  2020-11-06 12:22   colorlog/colorlog.py
     1256  2020-11-06 12:22   colorlog/escape_codes.py
     1610  2020-11-06 12:22   colorlog/logging.py
     1102  2020-11-09 06:39   colorlog-4.5.0.dist-info/LICENSE
     9721  2020-11-09 06:39   colorlog-4.5.0.dist-info/METADATA
      110  2020-11-09 06:39   colorlog-4.5.0.dist-info/WHEEL
        9  2020-11-09 06:39   colorlog-4.5.0.dist-info/top_level.txt
      701  2020-11-09 06:39   colorlog-4.5.0.dist-info/RECORD
---------                     -------
    23126                     9 files
# ^ all good, no tests, no docs

$ tar tf dist/colorlog-4.5.0.tar.gz 
colorlog-4.5.0/
colorlog-4.5.0/LICENSE
colorlog-4.5.0/MANIFEST.in
colorlog-4.5.0/PKG-INFO
colorlog-4.5.0/README.md
colorlog-4.5.0/colorlog/
colorlog-4.5.0/colorlog/__init__.py
colorlog-4.5.0/colorlog/colorlog.py
colorlog-4.5.0/colorlog/escape_codes.py
colorlog-4.5.0/colorlog/logging.py
colorlog-4.5.0/colorlog/tests/
colorlog-4.5.0/colorlog/tests/conftest.py
colorlog-4.5.0/colorlog/tests/test_colorlog.py
colorlog-4.5.0/colorlog/tests/test_config.ini
colorlog-4.5.0/colorlog/tests/test_config.py
colorlog-4.5.0/colorlog/tests/test_escape_codes.py
colorlog-4.5.0/colorlog/tests/test_example.py
colorlog-4.5.0/colorlog/tests/test_exports.py
colorlog-4.5.0/colorlog/tests/test_logging.py
colorlog-4.5.0/colorlog.egg-info/
colorlog-4.5.0/colorlog.egg-info/PKG-INFO
colorlog-4.5.0/colorlog.egg-info/SOURCES.txt
colorlog-4.5.0/colorlog.egg-info/dependency_links.txt
colorlog-4.5.0/colorlog.egg-info/requires.txt
colorlog-4.5.0/colorlog.egg-info/top_level.txt
colorlog-4.5.0/doc/
colorlog-4.5.0/doc/custom_level.py
colorlog-4.5.0/doc/example.png
colorlog-4.5.0/doc/example.py
colorlog-4.5.0/setup.cfg
colorlog-4.5.0/setup.py
# ^ all good, tests and docs included
```