### PR TITLE
Only init colorama on Windows

### DIFF
--- a/colorlog/escape_codes.py
+++ b/colorlog/escape_codes.py
@@ -5,13 +5,15 @@ http://en.wikipedia.org/wiki/ANSI_escape_code
 
 Uses colorama as an optional dependency to support color on Windows
 """
+import sys
 
 try:
     import colorama
 except ImportError:
     pass
 else:
-    colorama.init(strip=False)
+    if sys.platform == "win32":
+        colorama.init(strip=False)
 
 __all__ = ('escape_codes', 'parse_colors')
 


### PR DESCRIPTION
Currently, `colorlog` checks whether `colorama` is installed (importable), and calls `colorama.init()` if so. `colorlog` only requires `colorama` as a dependency on Windows platforms: https://github.com/borntyping/python-colorlog/blob/5580e2b3336b32ee0246d44cce5605ffda95c5b9/setup.py#L25-L27

This PR updates the `escape_codes` module to **only** initialize `colorama` on Windows platforms (`sys.platform == "win32"`). Note this is the _same_ logic which is used to gate the `colorama` dependency.

### Background

We've been seeing exceptions in our supervisor logging due to `colorama` being unexpectedly initialized:
```
Traceback (most recent call last):
  File "/home/app/.pex/unzipped_pexes/84659276c62b0e288dba64c1e1f55d821376d3c3/.deps/supervisor-4.2.0-py2.py3-none-any.whl/supervisor/loggers.py", line 102, in emit
    self.stream.write(msg)
  File "/home/app/.pex/unzipped_pexes/84659276c62b0e288dba64c1e1f55d821376d3c3/.deps/colorama-0.4.3-py2.py3-none-any.whl/colorama/ansitowin32.py", line 41, in write
    self.__convertor.write(text)
  File "/home/app/.pex/unzipped_pexes/84659276c62b0e288dba64c1e1f55d821376d3c3/.deps/colorama-0.4.3-py2.py3-none-any.whl/colorama/ansitowin32.py", line 162, in write
    self.write_and_convert(text)
  File "/home/app/.pex/unzipped_pexes/84659276c62b0e288dba64c1e1f55d821376d3c3/.deps/colorama-0.4.3-py2.py3-none-any.whl/colorama/ansitowin32.py", line 184, in write_and_convert
    text = self.convert_osc(text)
  File "/home/app/.pex/unzipped_pexes/84659276c62b0e288dba64c1e1f55d821376d3c3/.deps/colorama-0.4.3-py2.py3-none-any.whl/colorama/ansitowin32.py", line 246, in convert_osc
    for match in self.ANSI_OSC_RE.finditer(text):
TypeError: cannot use a string pattern on a bytes-like object
```

We tracked this down to the `colorama` init call inside of `colorlog`. In addition to `colorlog`, our application also depends on another library (`pycobertura`) which depends on `colorama`. As a result, `colorama` is importable and is initialized by `colorlog`, despite running on a non-Windows platform.
