### PR TITLE
Create a new ColoredFormatter preserving the formats of an existing one.

### DIFF
--- a/colorlog/__init__.py
+++ b/colorlog/__init__.py
@@ -12,6 +12,7 @@ from colorlog.colorlog import (
 
 from colorlog.logging import (
     basicConfig,
+    colorize,
     root,
     getLogger,
     log,
@@ -29,6 +30,7 @@ __all__ = (
     "default_log_colors",
     "escape_codes",
     "basicConfig",
+    "colorize",
     "root",
     "getLogger",
     "debug",

--- a/colorlog/logging.py
+++ b/colorlog/logging.py
@@ -38,6 +38,170 @@ def basicConfig(
         logging._releaseLock()
 
 
+def colorize(
+    formatter=None,
+    handler=None,
+    logger=None,
+    log_colors=None,
+    secondary_log_colors=None,
+    color_msg=True,
+    replace=True,
+    **kwargs
+):
+    """Colorize an existing formatter/handler/logger.
+
+    If you want to be able to log events in a failsafe way even if 'colorlog'
+    is not installed, you can use it as following:
+        >>> import logging
+        >>> logging.basicConfig(
+        ...     format='%(asctime)s %(levelname)-8s %(name)s: %(message)s',
+        ...     datefmt='%H:%M:%S')
+        >>> try:
+        ...     import colorlog
+        ... except ImportError
+        ...     pass
+        ... else:
+        ...     colorlog.colorize()
+    This will colorize the log, if 'colorlog' is available and keep the same
+    format as given in 'logging.basicConfig()' without supplying the formats
+    a second time to 'colorlog.basicConfig()'.
+
+    Here is another, more fancy example:
+        >>> import logging
+        >>> logging.basicConfig(
+        ...     format='%(asctime)s %(levelname)-8s %(name)s: %(message)s',
+        ...     datefmt='%H:%M:%S')
+        >>> try:
+        ...     import colorlog
+        ... except ImportError:
+        ...     pass
+        ... else:
+        ...     colorlog.colorize(
+        ...         log_colors={
+        ...             'DEBUG':    'cyan',
+        ...             'INFO':     'green',
+        ...             'WARNING':  'yellow',
+        ...             'ERROR':    'red',
+        ...             'CRITICAL': 'bold_red'},
+        ...         secondary_log_colors={
+        ...             'message': {
+        ...                 'ERROR':    'red',
+        ...                 'CRITICAL': 'bold_red'}},
+        ...         color_msg=False,
+        ...         levelname='log_color',
+        ...         name='bold',
+        ...         message='message_log_color')
+
+    Args:
+        formatter (logging.Formatter, optional):
+            Use the given formatter as a basis. This takes precedence over
+            'handler' and 'logger'.
+            Defaults to 'None', which uses the formatter from the handler
+            given in the 'handler' argument.
+        handler (logging.Handler, optional):
+            Use the formatter from this handler. This takes precedence over
+            'logger'.
+            Defaults to 'None', which uses the first handler of type
+            'logging.StreamHandler' from the logger given in the 'logger'
+            argument.
+        logger (logging.Logger, optional):
+            Use the formatter from the first 'logging.StreamHandler' found in
+            this logger.
+            Defaults to 'None', which uses the default root logger.
+        log_colors (dict, optional):
+            The primary colours passed to 'colorlog'.
+            Defaults to 'None', using the default colours.
+        secondary_log_colors(dict(dict), optional):
+            The secondary colours passed to 'colorlog'.
+            Defaults to 'None', meaning no secondary colors are defined.
+        color_msg (bool, optional):
+            If 'True', put a 'log_color' in front of the whole line. Set to
+            'False', if you want to do something fancy with the keyword
+            arguments (see '**kwargs').
+        replace (bool, optional):
+            If 'True', the formatter is replaced in the given or found handler.
+        **kwargs:
+            The keyword is the formatting token in the format string to be
+            encapsulated with a colour, given as value, if the format is:
+                '%(levelname)s:%(name)s:%(message)s'
+            and this function is called with:
+                levelname='log_color'
+            the format string becomes:
+                '%(log_color)s%(levelname)s%(reset)s:%(name)s:%(message)s'
+                 ^^^^^^^^^^^^^             ^^^^^^^^^
+
+    Returns:
+        logger.Formatter:
+            The new, colorized formatter.
+
+    """
+    if formatter is None:
+
+        if handler is None:
+
+            if logger is None:
+                # Use default logger
+                logger = logging.getLogger()
+
+            # Use first 'StreamHandler' as handler
+            for handler in logger.handlers:
+                if isinstance(handler, logging.StreamHandler):
+                    break
+            else:
+                raise TypeError(
+                    # f"No 'StreamHandler' found in logger '{logger}'.") # PY3
+                    f"No 'StreamHandler' found in logger '%s'." % logger)
+
+        # Use handler's formatter
+        formatter = handler.formatter
+
+    # Get the message and date formats
+    fmt = handler.formatter._fmt
+    datefmt = handler.formatter.datefmt
+
+    # Encapsulate all format tokens between the supplied colour and '%(reset)s'
+    for token, color in kwargs.items():
+        # Find full token between % and s
+        # We could use a regex for this, but don't want to load an extra module
+        try:
+            # Find the start
+            # start = fmt.find(f'%({token})') # PY3
+            start = fmt.find('%%(%s)' % token)
+        except ValueError:
+            # Ignore it
+            continue
+        try:
+            # Find end of it starting at the end of '%(token)', hence the '+3'
+            end = fmt.find('s', start + len(token) + 3)
+        except ValueError:
+            # Ignore it
+            continue
+
+        # Replace the token with its colour encapsulation
+        fulltoken = fmt[start:end+1]
+        #fmt = fmt.replace(fulltoken, f'%({color})s{fulltoken}%(reset)s') # PY3
+        fmt = fmt.replace(
+            fulltoken, f'%%(%s)s%s%%(reset)s' % (color, fulltoken))
+
+    if color_msg:
+        # Colorize the whole message
+        # fmt = f'%(log_color)s{fmt}' # PY3
+        fmt = f'%%(log_color)s%s' % fmt
+
+    # Make the new colored formatter
+    colored_formatter = ColoredFormatter(
+        fmt,
+        datefmt=datefmt,
+        log_colors=log_colors,
+        secondary_log_colors=secondary_log_colors)
+
+    if replace:
+        # Replace the default handler with the new colored version
+        handler.setFormatter(colored_formatter)
+
+    return colored_formatter
+
+
 def ensure_configured(func):
     """Modify a function to call ``basicConfig`` first if no handlers exist."""
 


### PR DESCRIPTION
The motivation behind this PR is that I want to have a failsafe way to have colored logs if `colorlog` is installed and the default logging behaviour if not. I could achieve this by calling `logging.basicConfig()` and `colorlog.basicConfig()` with the same parameters, but with this PR it is even easier:
```python3
import logging
logging.basicConfig(
    format='%(asctime)s %(levelname)-8s %(name)s: %(message)s',
    datefmt='%H:%M:%S')
try:
    import colorlog
except ImportError
    pass
else:
    colorlog.colorize()
```
because `colorlog.colorize()` called that way simply replaces the formatter with its coloured cousin, but preserving the log and date formats.