### PR TITLE
Upgrade Python syntax for Python 3

### DIFF
--- a/colorlog/__init__.py
+++ b/colorlog/__init__.py
@@ -1,7 +1,5 @@
 """A logging formatter for colored output."""
 
-from __future__ import absolute_import
-
 import sys
 import warnings
 

--- a/colorlog/colorlog.py
+++ b/colorlog/colorlog.py
@@ -1,7 +1,5 @@
 """The ColoredFormatter class."""
 
-from __future__ import absolute_import
-
 import logging
 import os
 import sys
@@ -39,7 +37,7 @@ default_formats = {
 }
 
 
-class ColoredRecord(object):
+class ColoredRecord:
     """
     Wraps a LogRecord, adding escape codes to the internal dict.
 
@@ -104,9 +102,9 @@ class ColoredFormatter(logging.Formatter):
         fmt = default_formats[style] if fmt is None else fmt
 
         if sys.version_info >= (3, 8):
-            super(ColoredFormatter, self).__init__(fmt, datefmt, style, validate)
+            super().__init__(fmt, datefmt, style, validate)
         else:
-            super(ColoredFormatter, self).__init__(fmt, datefmt, style)
+            super().__init__(fmt, datefmt, style)
 
         self.log_colors = log_colors if log_colors is not None else default_log_colors
         self.secondary_log_colors = (
@@ -120,7 +118,7 @@ class ColoredFormatter(logging.Formatter):
         """Format a message from a record object."""
         escapes = self._escape_code_map(record.levelname)
         wrapper = ColoredRecord(record, escapes)
-        message = super(ColoredFormatter, self).formatMessage(wrapper)  # type: ignore
+        message = super().formatMessage(wrapper)  # type: ignore
         message = self._append_reset(message, escapes)
         return message
 

--- a/colorlog/logging.py
+++ b/colorlog/logging.py
@@ -1,7 +1,5 @@
 """Wrappers around the logging module."""
 
-from __future__ import absolute_import
-
 import functools
 import logging
 import typing

--- a/colorlog/tests/conftest.py
+++ b/colorlog/tests/conftest.py
@@ -1,7 +1,5 @@
 """Fixtures that can be used in other tests."""
 
-from __future__ import print_function
-
 import inspect
 import logging
 import sys


### PR DESCRIPTION
Upgrade using https://github.com/asottile/pyupgrade `--py3-plus` to remove some redundant Python 2 stuff.