### PR TITLE
Drop support for EOL Python 3.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        python-version: ["3.5", "3.6", "3.7", "3.8", "3.9"]
+        python-version: ["3.6", "3.7", "3.8", "3.9"]
         dependencies: ["", "colorama"]
     steps:
       - uses: "actions/checkout@master"

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ Add colours to the output of Python's `logging` module.
 Status
 ------
 
-colorlog currently requires Python 3.5 or higher. Older versions (below 5.x.x) 
+colorlog currently requires Python 3.6 or higher. Older versions (below 5.x.x) 
 support Python 2.6 and above.
 
-* colorlog 6.x requires Python 3.5 or higher.
+* colorlog 6.x requires Python 3.6 or higher.
 * colorlog 5.x is an interim version that will warn Python 2 users to downgrade.
 * colorlog 4.x is the final version supporting Python 2.
 

--- a/colorlog/__init__.py
+++ b/colorlog/__init__.py
@@ -1,7 +1,5 @@
 """A logging formatter for colored output."""
 
-from __future__ import absolute_import
-
 import sys
 import warnings
 

--- a/colorlog/__init__.py
+++ b/colorlog/__init__.py
@@ -47,9 +47,9 @@ __all__ = (
     "TTYColoredFormatter",
 )
 
-if sys.version_info < (3, 5):
+if sys.version_info < (3, 6):
     warnings.warn(
-        "Colorlog requires Python 3.5 or above. Pin 'colorlog<5' to your dependencies "
+        "Colorlog requires Python 3.6 or above. Pin 'colorlog<5' to your dependencies "
         "if you require compatibility with older versions of Python. See "
         "https://github.com/borntyping/python-colorlog#status for more information."
     )

--- a/colorlog/colorlog.py
+++ b/colorlog/colorlog.py
@@ -1,7 +1,5 @@
 """The ColoredFormatter class."""
 
-from __future__ import absolute_import
-
 import logging
 import os
 import sys
@@ -39,7 +37,7 @@ default_formats = {
 }
 
 
-class ColoredRecord(object):
+class ColoredRecord:
     """
     Wraps a LogRecord, adding escape codes to the internal dict.
 
@@ -104,9 +102,9 @@ class ColoredFormatter(logging.Formatter):
         fmt = default_formats[style] if fmt is None else fmt
 
         if sys.version_info >= (3, 8):
-            super(ColoredFormatter, self).__init__(fmt, datefmt, style, validate)
+            super().__init__(fmt, datefmt, style, validate)
         else:
-            super(ColoredFormatter, self).__init__(fmt, datefmt, style)
+            super().__init__(fmt, datefmt, style)
 
         self.log_colors = log_colors if log_colors is not None else default_log_colors
         self.secondary_log_colors = (
@@ -120,7 +118,7 @@ class ColoredFormatter(logging.Formatter):
         """Format a message from a record object."""
         escapes = self._escape_code_map(record.levelname)
         wrapper = ColoredRecord(record, escapes)
-        message = super(ColoredFormatter, self).formatMessage(wrapper)  # type: ignore
+        message = super().formatMessage(wrapper)  # type: ignore
         message = self._append_reset(message, escapes)
         return message
 

--- a/colorlog/logging.py
+++ b/colorlog/logging.py
@@ -1,7 +1,5 @@
 """Wrappers around the logging module."""
 
-from __future__ import absolute_import
-
 import functools
 import logging
 import typing

--- a/colorlog/tests/conftest.py
+++ b/colorlog/tests/conftest.py
@@ -1,7 +1,5 @@
 """Fixtures that can be used in other tests."""
 
-from __future__ import print_function
-
 import inspect
 import logging
 import sys
@@ -50,7 +48,7 @@ def test_logger(reset_loggers, capsys):
         if validator is not None:
             for line in lines:
                 valid = validator(line.strip())
-                assert valid, "{!r} did not validate".format(line.strip())
+                assert valid, f"{line.strip()!r} did not validate"
 
         return lines
 

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
         ':sys_platform=="win32"': ["colorama"],
         "development": ["black", "flake8", "mypy", "pytest", "types-colorama"],
     },
+    python_requires=">=3.5",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Environment :: Console",
@@ -29,6 +30,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Topic :: Terminals",
         "Topic :: Utilities",
     ],

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
         ':sys_platform=="win32"': ["colorama"],
         "development": ["black", "flake8", "mypy", "pytest", "types-colorama"],
     },
-    python_requires=">=3.5",
+    python_requires=">=3.6",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Environment :: Console",
@@ -26,7 +26,6 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",


### PR DESCRIPTION
Python 3.5 is end-of-life since 13th September 2020:

https://endoflife.date/python

Here's the pip installs for colorlog from PyPI for May 2021, showing a very low proportion for 3.5:

| category | percent | downloads |
| -------- | ------: | --------: |
| 3.7      |  43.65% | 2,019,473 |
| null     |  21.04% |   973,149 |
| 3.8      |  16.65% |   770,477 |
| 3.6      |  12.42% |   574,697 |
| 3.9      |   3.78% |   174,853 |
| 2.7      |   1.64% |    75,890 |
| 3.5      |   0.73% |    33,899 |
| 3.10     |   0.07% |     3,324 |
| 3.4      |   0.01% |       409 |
| 2.6      |   0.00% |        26 |
| 3.3      |   0.00% |         4 |
| 3.2      |   0.00% |         2 |
| Total    |         | 4,626,203 |

Source: `pip install -U pypistats && pypistats python_minor colorlog --last-month`


This PR includes https://github.com/borntyping/python-colorlog/pull/105 and https://github.com/borntyping/python-colorlog/pull/106.