### PR TITLE
Add a force_color option

### DIFF
--- a/colorlog/formatter.py
+++ b/colorlog/formatter.py
@@ -111,7 +111,9 @@ class ColoredFormatter(logging.Formatter):
             super().__init__(fmt, datefmt, style)
 
         self.log_colors = log_colors if log_colors is not None else default_log_colors
-        self.secondary_log_colors = secondary_log_colors if secondary_log_colors is not None else {}
+        self.secondary_log_colors = (
+            secondary_log_colors if secondary_log_colors is not None else {}
+        )
         self.reset = reset
         self.stream = stream
         self.no_color = no_color
@@ -195,7 +197,9 @@ class LevelFormatter:
             }
         )
         """
-        self.formatters = {level: ColoredFormatter(fmt=f, **kwargs) for level, f in fmt.items()}
+        self.formatters = {
+            level: ColoredFormatter(fmt=f, **kwargs) for level, f in fmt.items()
+        }
 
     def format(self, record: logging.LogRecord) -> str:
         return self.formatters[record.levelname].format(record)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="colorlog",
-    version="6.5.0",
+    version="6.6.0",
     description="Add colours to the output of Python's logging module.",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This should provide a workaround for #112, where calling basicConfig
with stream=sys.stdout forced color detection though istty, with no
way to disable it.