### PR TITLE
set default stream to sys.stderror

### DIFF
--- a/colorlog/formatter.py
+++ b/colorlog/formatter.py
@@ -69,7 +69,7 @@ class ColoredFormatter(logging.Formatter):
         reset: bool = True,
         secondary_log_colors: typing.Optional[SecondaryLogColors] = None,
         validate: bool = True,
-        stream: typing.Optional[typing.IO] = None,
+        stream: typing.IO = sys.stderr,
         no_color: bool = False,
         force_color: bool = False,
         defaults: typing.Optional[typing.Mapping[str, typing.Any]] = None,
@@ -156,7 +156,7 @@ class ColoredFormatter(logging.Formatter):
         if self.no_color or "NO_COLOR" in os.environ:
             return True
 
-        if self.stream is not None and not self.stream.isatty():
+        if not self.stream.isatty():
             return True
 
         return False

--- a/colorlog/wrappers.py
+++ b/colorlog/wrappers.py
@@ -2,6 +2,7 @@
 
 import functools
 import logging
+import sys
 import typing
 from logging import (
     CRITICAL,
@@ -64,7 +65,7 @@ def basicConfig(
                 log_colors=log_colors,
                 reset=reset,
                 secondary_log_colors=secondary_log_colors,
-                stream=kwargs.get("stream", None),
+                stream=kwargs.get("stream", sys.stderr),
             )
         )
     finally:

--- a/sample.py
+++ b/sample.py
@@ -2,7 +2,7 @@ import logging
 import colorlog
 
 fmt = "{log_color}{levelname} {name}: {message}"
-colorlog.basicConfig(level=logging.DEBUG, style="{", format=fmt, stream=None)
+colorlog.basicConfig(level=logging.DEBUG, style="{", format=fmt)
 
 log = logging.getLogger()
 


### PR DESCRIPTION
Since python `StreamHandler`'s `stream` is [defaulted to `sys.stderror`](https://github.com/python/cpython/blob/main/Lib/logging/__init__.py#L1133-L1135). It might be natural to set the default stream to `sys.stderror`.