### PR TITLE
Fix running tests in environment with NO_COLOR=1

### DIFF
--- a/colorlog/tests/conftest.py
+++ b/colorlog/tests/conftest.py
@@ -28,6 +28,12 @@ def assert_log_message(capsys, log_function, message, *args):
     return err
 
 
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch):
+    monkeypatch.delenv("FORCE_COLOR", raising=False)
+    monkeypatch.delenv("NO_COLOR", raising=False)
+
+
 @pytest.fixture()
 def reset_loggers():
     logging.root.handlers = list()


### PR DESCRIPTION
Fix running the test suite when pytest is run with NO_COLOR=1 set in the environment.  An fixture is autoused to ensure that the variables are removed for the scope of the test, while they are respected e.g. by pytest itself.