### PR TITLE
fix(doc): Update package links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@ Log formatting with colors!
 
 [![](https://img.shields.io/pypi/v/colorlog.svg)](https://pypi.org/project/colorlog/)
 [![](https://img.shields.io/pypi/l/colorlog.svg)](https://pypi.org/project/colorlog/)
-[![](https://img.shields.io/travis/borntyping/python-colorlog/master.svg)](https://travis-ci.org/borntyping/python-colorlog)
 
 Add colours to the output of Python's `logging` module.
 
@@ -40,9 +39,9 @@ Install from PyPI with:
 pip install colorlog
 ```
 
-Several Linux distributions provide official packages ([Debian], [Fedora], 
+Several Linux distributions provide official packages ([Debian], [Arch], [Fedora], 
 [Gentoo], [OpenSuse] and [Ubuntu]), and others have user provided packages
-([Arch AUR], [BSD ports], [Conda]).
+([BSD ports], [Conda]).
 
 Usage
 -----
@@ -268,11 +267,11 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 [addLevelName]: https://docs.python.org/3/library/logging.html#logging.addLevelName
 [Formatter]: http://docs.python.org/3/library/logging.html#logging.Formatter
 [tox]: http://tox.readthedocs.org/
-[Arch AUR]: https://aur.archlinux.org/packages/python-colorlog/
+[Arch]: https://archlinux.org/packages/extra/any/python-colorlog/
 [BSD ports]: https://www.freshports.org/devel/py-colorlog/
 [colorama]: https://pypi.python.org/pypi/colorama
 [Conda]: https://anaconda.org/conda-forge/colorlog
-[Debian]: https://packages.debian.org/buster/python3-colorlog
+[Debian]: [https://packages.debian.org/buster/python3-colorlog](https://packages.debian.org/buster/python3-colorlog)
 [Errbot]: http://errbot.io/
 [Fedora]: https://src.fedoraproject.org/rpms/python-colorlog
 [Gentoo]: https://packages.gentoo.org/packages/dev-python/colorlog


### PR DESCRIPTION
Hello,

- TravisCI badge removed because the link was dead and I assume you migrated to Microsoft GitHub Actions because they also do exist
- Package links to Debian and Arch are updated.
  - Debian now points to the source package independet from a specific Debian release.
  - Arch moved the package from AUR to its "extra" repo. I treat this as "official". But I am not sure about that.

Please let me add two problems I discovered:
1. I couldn't find a contribution information (e.g. CONTRIB.md) or something else. It is not clear how to provide a PR. I assume the `develop` branch is the correct target.
2. The README.md suffix indicates this is a markdown file. But its content make it clear that it is a restructured-text (rst) file.