### PR TITLE
Support python 3.13

### DIFF
--- a/colorlog/wrappers.py
+++ b/colorlog/wrappers.py
@@ -70,7 +70,7 @@ def basicConfig(
         )
 
     if sys.version_info >= (3, 13):
-        with logging._lock:
+        with logging._lock:  # type: ignore
             _basicConfig()
     else:
         logging._acquireLock()  # type: ignore


### PR DESCRIPTION
The functional code to support python3.13 was already in the repo, but the mypy tests were failing. This pull request fixes this issue. See also Issue #134

This should allow a release of the library that supports python 3.13.x