### PR TITLE
When logging exceptions, enable colorized traceback

### DIFF
--- a/colorlog/formatter.py
+++ b/colorlog/formatter.py
@@ -4,6 +4,8 @@ import logging
 import os
 import sys
 import typing
+import traceback
+import io
 
 import colorlog.escape_codes
 
@@ -174,6 +176,29 @@ class ColoredFormatter(logging.Formatter):
             message += reset_escape_code
 
         return message
+
+    if sys.version_info >= (3, 13):
+
+        def formatException(self, ei):
+            """Format and return the specified exception information as a string."""
+            # This is a copy of logging.Formatter.formatException that passes in
+            # an appropriate value for colorize to print_exception.
+
+            sio = io.StringIO()
+            tb = ei[2]
+            traceback.print_exception(
+                ei[0],
+                ei[1],
+                tb,
+                limit=None,
+                file=sio,
+                colorize=not self._blank_escape_codes(),
+            )
+            s = sio.getvalue()
+            sio.close()
+            if s[-1:] == "\n":
+                s = s[:-1]
+            return s
 
 
 class LevelFormatter:


### PR DESCRIPTION
This uses the colorized tracebacks that were introduced in python3.13. 

E.G.:

```python
import logging
import colorlog

fmt = "{log_color}{levelname} {name}: {message}"
colorlog.basicConfig(level=logging.DEBUG, style="{", format=fmt, stream=None)

log = logging.getLogger()

try:
    raise Exception("foo")
except Exception:
    log.exception("Error: ")

```


<img width="1052" height="707" alt="image" src="https://github.com/user-attachments/assets/10d66bac-b3b6-4f49-88b9-8997c0c6e469" />
